### PR TITLE
Modifications to get nodes including parenthesis

### DIFF
--- a/corpus/block_commands.txt
+++ b/corpus/block_commands.txt
@@ -10,12 +10,15 @@ endfunction()
   (function_def
     (function_command
       (function)
-      (argument
-        (unquoted_argument)
+      (paren_argument
+        (argument
+          (unquoted_argument)
+        )
       )
     )
     (endfunction_command
       (endfunction)
+      (paren_argument)
     )
   )
 )
@@ -32,21 +35,24 @@ endfunction()
   (function_def
     (function_command
       (function)
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
+      (paren_argument
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
       )
     )
     (endfunction_command
       (endfunction)
+      (paren_argument)
     )
   )
 )
@@ -63,12 +69,15 @@ endmacro()
   (macro_def
     (macro_command
       (macro)
-      (argument
-        (unquoted_argument)
+      (paren_argument
+        (argument
+          (unquoted_argument)
+        )
       )
     )
     (endmacro_command
       (endmacro)
+      (paren_argument)
     )
   )
 )
@@ -85,21 +94,24 @@ endmacro()
   (macro_def
     (macro_command
       (macro)
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
+      (paren_argument
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
       )
     )
     (endmacro_command
       (endmacro)
+      (paren_argument)
     )
   )
 )
@@ -116,24 +128,27 @@ endblock()
   (block_def
     (block_command
       (block)
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
-      )
-      (argument
-        (unquoted_argument)
+      (paren_argument
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
+        (argument
+          (unquoted_argument)
+        )
       )
     )
     (endblock_command
       (endblock)
+      (paren_argument)
     )
   )
 )

--- a/corpus/bracket_argument.txt
+++ b/corpus/bracket_argument.txt
@@ -8,7 +8,9 @@ message([[]])
 (source_file
  (normal_command
   (identifier)
-  (argument (bracket_argument))
+  (paren_argument
+   (argument (bracket_argument))
+  )
  )
  )
 
@@ -22,7 +24,9 @@ message([[an argument]])
 (source_file
  (normal_command
   (identifier)
-  (argument (bracket_argument))
+  (paren_argument
+   (argument (bracket_argument))
+  )
  )
  )
 
@@ -36,8 +40,10 @@ message([[first argument]] [[second argument]])
 (source_file
  (normal_command
   (identifier)
-  (argument (bracket_argument))
-  (argument (bracket_argument))
+  (paren_argument
+   (argument (bracket_argument))
+   (argument (bracket_argument))
+  )
  )
  )
 
@@ -54,8 +60,10 @@ message(
 (source_file
  (normal_command
   (identifier)
-  (argument (bracket_argument))
-  (argument (bracket_argument))
+  (paren_argument
+   (argument (bracket_argument))
+   (argument (bracket_argument))
+  )
  )
  )
 
@@ -71,7 +79,9 @@ with line break
 (source_file
  (normal_command
   (identifier)
-  (argument (bracket_argument))
+  (paren_argument
+   (argument (bracket_argument))
+  )
  )
  )
 
@@ -87,7 +97,9 @@ with line break ]==]
 (source_file
  (normal_command
   (identifier)
-  (argument (bracket_argument))
+  (paren_argument
+   (argument (bracket_argument))
+  )
  )
  )
 

--- a/corpus/comment.txt
+++ b/corpus/comment.txt
@@ -19,10 +19,12 @@ message(STATUS #[[Some comment]] "comment is next" #[[Some comment]])
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
-  (bracket_comment)
-  (argument (quoted_argument (quoted_element)))
-  (bracket_comment)
+  (paren_argument
+   (argument (unquoted_argument))
+   (bracket_comment)
+   (argument (quoted_argument (quoted_element)))
+   (bracket_comment)
+  )
  )
 )
 
@@ -50,9 +52,11 @@ Second #Some other line comment
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
-  (line_comment)
-  (argument (unquoted_argument))
-  (line_comment)
+  (paren_argument
+   (argument (unquoted_argument))
+   (line_comment)
+   (argument (unquoted_argument))
+   (line_comment)
+  )
  )
 )

--- a/corpus/condition.txt
+++ b/corpus/condition.txt
@@ -9,10 +9,12 @@ endif()
 (source_file
   (if_condition
     (if_command
-      (if)
-      (argument (unquoted_argument))
+    	(if)
+		(paren_argument
+      		(argument (unquoted_argument))
+		)
     )
-    (endif_command (endif))
+    (endif_command (endif) (paren_argument))
   )
 )
 
@@ -29,13 +31,13 @@ endif()
   (if_condition
     (if_command
       (if)
-      (argument (unquoted_argument))
+      (paren_argument (argument (unquoted_argument)))
     )
     (elseif_command
       (elseif)
-      (argument (unquoted_argument))
+      (paren_argument (argument (unquoted_argument)))
     )
-    (endif_command (endif))
+    (endif_command (endif) (paren_argument))
   )
 )
 
@@ -53,14 +55,14 @@ endif()
   (if_condition
     (if_command
       (if)
-      (argument (unquoted_argument))
+      (paren_argument (argument (unquoted_argument)))
     )
     (elseif_command
       (elseif)
-      (argument (unquoted_argument))
+      (paren_argument (argument (unquoted_argument)))
     )
-    (else_command (else))
-    (endif_command (endif))
+    (else_command (else) (paren_argument))
+    (endif_command (endif) (paren_argument))
   )
 )
 
@@ -77,13 +79,13 @@ endif()
  (if_condition
   (if_command
    (if)
-   (argument (unquoted_argument))
+   (paren_argument (argument (unquoted_argument)))
   )
   (normal_command
    (identifier)
-   (argument (unquoted_argument))
+   (paren_argument (argument (unquoted_argument)))
   )
-  (endif_command (endif))
+  (endif_command (endif) (paren_argument))
  )
 )
 
@@ -97,13 +99,17 @@ endif()
  (if_condition
   (if_command
    (if)
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
+   (paren_argument
+	(paren_argument
+   		(argument (unquoted_argument))
+   		(argument (unquoted_argument))
+   		(argument (unquoted_argument))
+	)
+   	(argument (unquoted_argument))
+   	(argument (unquoted_argument))
+   )
   )
-  (endif_command (endif))
+  (endif_command (endif) (paren_argument))
  )
 )
 
@@ -118,30 +124,42 @@ endif(NOT (A AND B) OR C)
  (if_condition
   (if_command
    (if)
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
+	(paren_argument
+   		(argument (unquoted_argument))
+		(paren_argument
+   			(argument (unquoted_argument))
+   			(argument (unquoted_argument))
+   			(argument (unquoted_argument))
+		)
+   		(argument (unquoted_argument))
+   		(argument (unquoted_argument))
+	)
   )
   (else_command
-   (else)
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
+	(else)
+	(paren_argument
+   		(argument (unquoted_argument))
+		(paren_argument
+   			(argument (unquoted_argument))
+   			(argument (unquoted_argument))
+   			(argument (unquoted_argument))
+		)
+   		(argument (unquoted_argument))
+   		(argument (unquoted_argument))
+	)
   )
   (endif_command 
-   (endif)
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
-   (argument (unquoted_argument))
+	(endif)
+	(paren_argument
+   		(argument (unquoted_argument))
+		(paren_argument
+   			(argument (unquoted_argument))
+   			(argument (unquoted_argument))
+   			(argument (unquoted_argument))
+		)
+   		(argument (unquoted_argument))
+   		(argument (unquoted_argument))
+	)
   )
  )
 )

--- a/corpus/escape_sequence.txt
+++ b/corpus/escape_sequence.txt
@@ -9,10 +9,11 @@ set(var "It is \; and \"")
 (source_file
   (normal_command
     (identifier)
-    (argument
-      (unquoted_argument))
-    (argument
-      (quoted_argument
-        (quoted_element
-          (escape_sequence)
-          (escape_sequence))))))
+    (paren_argument
+      (argument
+        (unquoted_argument))
+      (argument
+        (quoted_argument
+          (quoted_element
+            (escape_sequence)
+            (escape_sequence)))))))

--- a/corpus/foreach.txt
+++ b/corpus/foreach.txt
@@ -11,9 +11,11 @@ endforeach()
  (foreach_loop
   (foreach_command
     (foreach)
-    (argument (unquoted_argument))
+    (paren_argument
+     (argument (unquoted_argument))
+    )
   )
-  (endforeach_command (endforeach))
+  (endforeach_command (endforeach) (opt_argument))
  )
  )
 
@@ -30,11 +32,15 @@ endforeach(var)
  (foreach_loop
   (foreach_command
     (foreach)
-    (argument (unquoted_argument))
+    (paren_argument
+     (argument (unquoted_argument))
+    )
   )
   (endforeach_command
     (endforeach)
-    (argument (unquoted_argument))
+    (opt_argument
+     (argument (unquoted_argument))
+    )
   )
  ))
 
@@ -51,9 +57,11 @@ ENDFOREACH()
  (foreach_loop
   (foreach_command
     (foreach)
-    (argument (unquoted_argument))
+    (paren_argument
+     (argument (unquoted_argument))
+    )
   )
-  (endforeach_command (endforeach))
+  (endforeach_command (endforeach) (opt_argument))
  )
  )
 
@@ -70,9 +78,11 @@ endForEach()
  (foreach_loop
   (foreach_command
     (foreach)
-    (argument (unquoted_argument))
+    (paren_argument
+     (argument (unquoted_argument))
+    )
   )
-  (endforeach_command (endforeach))
+  (endforeach_command (endforeach) (opt_argument))
  )
  )
 
@@ -89,10 +99,12 @@ endforeach()
  (foreach_loop
   (foreach_command
     (foreach)
-    (argument (unquoted_argument))
-    (argument (unquoted_argument))
+    (paren_argument
+     (argument (unquoted_argument))
+     (argument (unquoted_argument))
+    )
   )
-  (endforeach_command (endforeach))
+  (endforeach_command (endforeach) (opt_argument))
  )
  )
 
@@ -109,9 +121,11 @@ endforeach()
  (foreach_loop
   (foreach_command
     (foreach)
-    (argument (unquoted_argument))
-    (argument (unquoted_argument))
+    (paren_argument
+     (argument (unquoted_argument))
+     (argument (unquoted_argument))
+    )
   )
-  (endforeach_command (endforeach))
+  (endforeach_command (endforeach) (opt_argument))
  )
  )

--- a/corpus/function_calls.txt
+++ b/corpus/function_calls.txt
@@ -9,8 +9,10 @@ add_custom_target(OUTPUT somefile)
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
-  (argument (unquoted_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+   (argument (unquoted_argument))
+  )
  )
  )
 
@@ -26,7 +28,9 @@ add_custom_target(
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
-  (argument (unquoted_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+   (argument (unquoted_argument))
+  )
  )
  )

--- a/corpus/gen_exp.txt
+++ b/corpus/gen_exp.txt
@@ -8,9 +8,10 @@ message($<>)
 (source_file
   (normal_command
     (identifier)
+    (paren_argument
     (argument
       (unquoted_argument
-        (gen_exp)))))
+        (gen_exp))))))
 
 =====================================
 Quoted generator expression [gen_exp]
@@ -22,10 +23,11 @@ message("$<>")
 (source_file
   (normal_command
     (identifier)
+    (paren_argument
     (argument
       (quoted_argument
         (quoted_element
-          (gen_exp))))))
+          (gen_exp)))))))
 
 =====================
 No argument [gen_exp]
@@ -37,11 +39,12 @@ message($<ANGLE-R>)
 (source_file
   (normal_command
     (identifier)
+    (paren_argument
     (argument
       (unquoted_argument
         (gen_exp
           (argument
-            (unquoted_argument)))))))
+            (unquoted_argument))))))))
 
 ============================================
 No argument with superfluous colon [gen_exp]
@@ -53,11 +56,12 @@ message($<ANGLE-R:>)
 (source_file
   (normal_command
     (identifier)
+    (paren_argument
     (argument
       (unquoted_argument
         (gen_exp
           (argument
-            (unquoted_argument)))))))
+            (unquoted_argument))))))))
 
 ======================
 One argument [gen_exp]
@@ -69,13 +73,14 @@ message($<BOOL:-NOTFOUND>)
 (source_file
   (normal_command
     (identifier)
+    (paren_argument
     (argument
       (unquoted_argument
         (gen_exp
           (argument
             (unquoted_argument))
           (argument
-            (unquoted_argument)))))))
+            (unquoted_argument))))))))
 
 =======================
 Two arguments [gen_exp]
@@ -87,12 +92,13 @@ message($<AND:TRUE,FALSE>)
 (source_file
   (normal_command
     (identifier)
-    (argument
-      (unquoted_argument
-        (gen_exp
-          (argument
-            (unquoted_argument))
-          (argument
-            (unquoted_argument))
-          (argument
-            (unquoted_argument)))))))
+    (paren_argument
+      (argument
+        (unquoted_argument
+          (gen_exp
+            (argument
+              (unquoted_argument))
+            (argument
+              (unquoted_argument))
+            (argument
+              (unquoted_argument))))))))

--- a/corpus/message.txt
+++ b/corpus/message.txt
@@ -9,6 +9,7 @@ message()
 (source_file
  (normal_command
   (identifier)
+  (paren_argument)
  )
  )
 
@@ -23,6 +24,7 @@ message( )
 (source_file
  (normal_command
   (identifier)
+  (paren_argument)
  )
  )
 
@@ -39,6 +41,7 @@ message(
 (source_file
  (normal_command
   (identifier)
+  (paren_argument)
  )
  )
 
@@ -53,8 +56,10 @@ message(STATUS [=[Some argument ]==] ]=] )
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
-  (argument (bracket_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+   (argument (bracket_argument))
+  )
  )
  )
 
@@ -71,8 +76,10 @@ message(STATUS
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
-  (argument (bracket_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+   (argument (bracket_argument))
+  )
  )
  )
 
@@ -87,7 +94,9 @@ message(STATUS argument)
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
-  (argument (unquoted_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+   (argument (unquoted_argument))
+  )
  )
  )

--- a/corpus/parentheses.txt
+++ b/corpus/parentheses.txt
@@ -6,8 +6,12 @@ message(STATUS (TEST))
 (source_file
   (normal_command
     (identifier)
-    (argument (unquoted_argument))
-    (argument (unquoted_argument))
+    (paren_argument
+      (argument (unquoted_argument))
+      (paren_argument
+        (argument (unquoted_argument))
+      )
+    )
   )
 )
 
@@ -19,8 +23,13 @@ message(STATUS (TEST)
 (source_file
   (normal_command
     (identifier)
-    (argument (unquoted_argument))
-    (argument (unquoted_argument)) (MISSING ")")
+    (paren_argument
+      (argument (unquoted_argument))
+      (paren_argument
+        (argument (unquoted_argument))
+      )
+      (MISSING ")")
+    )
   )
 )
 
@@ -32,8 +41,15 @@ message(STATUS ((TEST))
 (source_file
   (normal_command
     (identifier)
-    (argument (unquoted_argument))
-    (argument (unquoted_argument)) (MISSING ")")
+    (paren_argument
+      (argument (unquoted_argument))
+      (paren_argument
+        (paren_argument
+          (argument (unquoted_argument)) 
+        )
+      )
+      (MISSING ")")
+    )
   )
 )
 
@@ -45,8 +61,12 @@ message(STATUS (TEST SECOND_TEST))
 (source_file
   (normal_command
     (identifier)
-    (argument (unquoted_argument))
-    (argument (unquoted_argument))
-    (argument (unquoted_argument))
+    (paren_argument
+      (argument (unquoted_argument))
+      (paren_argument
+        (argument (unquoted_argument))
+        (argument (unquoted_argument))
+      )
+    )
   )
 )

--- a/corpus/quoted_argument.txt
+++ b/corpus/quoted_argument.txt
@@ -8,7 +8,9 @@ message("")
 (source_file
  (normal_command
   (identifier)
-  (argument (quoted_argument))
+  (paren_argument
+   (argument (quoted_argument))
+  )
  )
  )
 
@@ -22,7 +24,9 @@ message("An argument")
 (source_file
  (normal_command
   (identifier)
-  (argument (quoted_argument (quoted_element)))
+  (paren_argument
+   (argument (quoted_argument (quoted_element)))
+  )
  )
  )
 
@@ -36,8 +40,10 @@ message("First argument" "Second argument")
 (source_file
  (normal_command
   (identifier)
-  (argument (quoted_argument (quoted_element)))
-  (argument (quoted_argument (quoted_element)))
+  (paren_argument
+   (argument (quoted_argument (quoted_element)))
+   (argument (quoted_argument (quoted_element)))
+  )
  )
  )
 
@@ -52,7 +58,9 @@ with line break")
 (source_file
  (normal_command
   (identifier)
-  (argument (quoted_argument (quoted_element)))
+  (paren_argument
+   (argument (quoted_argument (quoted_element)))
+  )
  )
  )
 
@@ -66,10 +74,12 @@ message("${var}")
 (source_file
  (normal_command
   (identifier)
-  (argument
-   (quoted_argument
-    (quoted_element
-     (variable_ref (normal_var (variable)))
+  (paren_argument
+   (argument
+    (quoted_argument
+     (quoted_element
+      (variable_ref (normal_var (variable)))
+     )
     )
    )
   )
@@ -86,11 +96,13 @@ message("${var} ${var}")
 (source_file
  (normal_command
   (identifier)
-  (argument
-   (quoted_argument
-    (quoted_element
-     (variable_ref (normal_var (variable)))
-     (variable_ref (normal_var (variable)))
+  (paren_argument
+   (argument
+    (quoted_argument
+     (quoted_element
+      (variable_ref (normal_var (variable)))
+      (variable_ref (normal_var (variable)))
+     )
     )
    )
   )
@@ -107,10 +119,12 @@ message("${var_${var}}")
 (source_file
  (normal_command
   (identifier)
-  (argument
-   (quoted_argument
-    (quoted_element
-     (variable_ref (normal_var (variable (variable_ref (normal_var (variable))))))
+  (paren_argument
+   (argument
+    (quoted_argument
+     (quoted_element
+      (variable_ref (normal_var (variable (variable_ref (normal_var (variable))))))
+     )
     )
    )
   )
@@ -127,10 +141,12 @@ message("${var_${var}} #[[comment]]")
 (source_file
  (normal_command
   (identifier)
-  (argument
-   (quoted_argument
-    (quoted_element
-     (variable_ref (normal_var (variable (variable_ref (normal_var (variable))))))
+  (paren_argument
+   (argument
+    (quoted_argument
+     (quoted_element
+      (variable_ref (normal_var (variable (variable_ref (normal_var (variable))))))
+     )
     )
    )
   )
@@ -147,10 +163,12 @@ message("${var_${var}} #comment")
 (source_file
  (normal_command
   (identifier)
-  (argument
-   (quoted_argument
-    (quoted_element
-     (variable_ref (normal_var (variable (variable_ref (normal_var (variable))))))
+  (paren_argument
+   (argument
+    (quoted_argument
+     (quoted_element
+      (variable_ref (normal_var (variable (variable_ref (normal_var (variable))))))
+     )
     )
    )
   )
@@ -167,9 +185,11 @@ message("$var")
 (source_file
  (normal_command
   (identifier)
-  (argument
-   (quoted_argument
-    (quoted_element)
+  (paren_argument
+   (argument
+    (quoted_argument
+     (quoted_element)
+    )
    )
   )
  )

--- a/corpus/unquoted_argument.txt
+++ b/corpus/unquoted_argument.txt
@@ -9,7 +9,9 @@ message(STATUS)
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+  )
  )
  )
 
@@ -24,8 +26,10 @@ message(STATUS Hello)
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
-  (argument (unquoted_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+   (argument (unquoted_argument))
+  )
  )
  )
 
@@ -41,11 +45,15 @@ STATUS)
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+  )
  )
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+  )
  )
 )
 ============================================================
@@ -60,11 +68,15 @@ STATUS)
 (source_file
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+  )
  )
  (normal_command
   (identifier)
-  (argument (unquoted_argument))
+  (paren_argument
+   (argument (unquoted_argument))
+  )
  )
  )
 
@@ -77,9 +89,11 @@ message(${var_ref})
 (source_file
  (normal_command
   (identifier)
-  (argument
-   (unquoted_argument
-    (variable_ref (normal_var (variable)))
+  (paren_argument
+   (argument
+    (unquoted_argument
+     (variable_ref (normal_var (variable)))
+    )
    )
   )
  )
@@ -94,9 +108,11 @@ message(${var_${var_ref}})
 (source_file
  (normal_command
   (identifier)
-  (argument
-   (unquoted_argument
-    (variable_ref (normal_var (variable (variable_ref (normal_var (variable))))))
+  (paren_argument
+   (argument
+    (unquoted_argument
+     (variable_ref (normal_var (variable (variable_ref (normal_var (variable))))))
+    )
    )
   )
  )
@@ -112,8 +128,10 @@ message($var)
 (source_file
  (normal_command
   (identifier)
-  (argument
-   (unquoted_argument)
+  (paren_argument
+   (argument
+    (unquoted_argument)
+   )
   )
  )
 )

--- a/corpus/while.txt
+++ b/corpus/while.txt
@@ -11,9 +11,11 @@ endwhile()
   (while_loop
     (while_command
       (while)
-      (argument (unquoted_argument))
+      (paren_argument
+        (argument (unquoted_argument))
+      )
     )
-    (endwhile_command (endwhile))
+    (endwhile_command (endwhile) (opt_argument))
   )
 )
 
@@ -30,11 +32,15 @@ endwhile(cond)
   (while_loop
     (while_command
       (while)
-      (argument (unquoted_argument))
+      (paren_argument
+        (argument (unquoted_argument))
+      )
     )
     (endwhile_command 
       (endwhile)
-      (argument (unquoted_argument))
+      (opt_argument
+        (argument (unquoted_argument))
+      )
     )
   )
 )


### PR DESCRIPTION
Adds a node with parenthesis. This is needed in helix-editor to allow match parenthesis to work.