### PR TITLE
refactor: use C for the external scanner

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,7 +9,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
-        # If your language uses an external scanner, add it here.
+		"src/scanner.c",
       ],
       "cflags_c": [
         "-std=c99",

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,7 +2,7 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
+    c_config.include(src_dir);
     c_config
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
@@ -10,29 +10,10 @@ fn main() {
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
-
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
-
-    // If your language uses an external scanner written in C++,
-    // then include this block of code:
-
-    let mut cpp_config = cc::Build::new();
-    cpp_config.cpp(true);
-    cpp_config.include(&src_dir);
-    cpp_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable");
-    let scanner_path = src_dir.join("scanner.cc");
-    cpp_config.file(&scanner_path);
-    cpp_config.compile("scanner");
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,12 +1,11 @@
-#include <cwctype>
 #include <tree_sitter/parser.h>
+#include <wctype.h>
 
-namespace {
 enum TokenType { BRACKET_ARGUMENT, BRACKET_COMMENT, LINE_COMMENT };
 void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
 void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 void skip_wspace(TSLexer *lexer) {
-  while (std::iswspace(lexer->lookahead)) {
+  while (iswspace(lexer->lookahead)) {
     skip(lexer);
   }
 }
@@ -72,8 +71,6 @@ bool scan(void *payload, TSLexer *lexer, bool const *valid_symbols) {
   return false;
 }
 
-} // namespace
-extern "C" {
 void *tree_sitter_cmake_external_scanner_create() { return NULL; }
 void tree_sitter_cmake_external_scanner_destroy(void *payload) {}
 unsigned tree_sitter_cmake_external_scanner_serialize(void *payload,
@@ -86,5 +83,4 @@ void tree_sitter_cmake_external_scanner_deserialize(void *payload,
 bool tree_sitter_cmake_external_scanner_scan(void *payload, TSLexer *lexer,
                                              bool const *valid_symbols) {
   return scan(payload, lexer, valid_symbols);
-}
 }


### PR DESCRIPTION
Mainly for portability and ease of compilation