### PR TITLE
fix: generate with `strict` mode

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,4 +1,4 @@
-commands = [
+const commands = [
   "if",
   "elseif",
   "else",


### PR DESCRIPTION
The grammar will fail to evaluate if JS is run in 'strict mode', since the variable assignment for `commands` is assigning it as a global, which is disallowed in strict mode.