### PR TITLE
WIP: build: migrate to wasm-based build and add smoke tests

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,0 +1,16 @@
+const fs = require("fs");
+const path = require("path");
+
+let wasm;
+
+if (typeof process === "object" && process.versions?.node) {
+  // Node — export the wasm as a Buffer
+  const wasmPath = path.resolve(__dirname, "./tree-sitter-cmake.wasm");
+  wasm = fs.readFileSync(wasmPath);
+} else {
+  // Browser / Bundler / Deno
+  const { pathToFileURL } = require("url");
+  wasm = new URL("./tree-sitter-cmake.wasm", pathToFileURL(__filename)).href;
+}
+
+module.exports = wasm;

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,19 @@
+let wasm;
+
+if (typeof process === "object" && process.versions?.node) {
+  // Node - export the wasm as a buffer
+  const { readFileSync } = await import("node:fs");
+  const { fileURLToPath } = await import("node:url");
+  const { dirname, resolve } = await import("node:path");
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const wasmPath = resolve(__dirname, "./tree-sitter-cmake.wasm");
+
+  wasm = readFileSync(wasmPath);
+} else {
+  // Browser / Bundler / Deno
+  wasm = new URL("./tree-sitter-cmake.wasm", import.meta.url).href;
+}
+
+export { wasm };
+export default wasm;

--- a/npm-test/cjs/package.json
+++ b/npm-test/cjs/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/npm-test/cjs/smoke.test.cjs
+++ b/npm-test/cjs/smoke.test.cjs
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { Parser, Language } = require('web-tree-sitter');
+
+const cmake = require('../../index.cjs');
+
+let lang;
+
+test.before(async () => {
+  await Parser.init();
+  lang = await Language.load(cmake);
+});
+
+test('wasm grammar loads', async () => {
+  assert.ok(lang);
+});
+
+test('can parse a simple file', async () => {
+  const parser = new Parser();
+  parser.setLanguage(lang)
+  const tree = parser.parse('project(foo)');
+  assert.equal(tree?.rootNode?.type, 'source_file');
+});

--- a/npm-test/mjs/package.json
+++ b/npm-test/mjs/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/npm-test/mjs/smoke.test.mjs
+++ b/npm-test/mjs/smoke.test.mjs
@@ -1,0 +1,20 @@
+import test from 'node:test'
+import assert from 'node:assert'
+
+import { Parser, Language } from 'web-tree-sitter';
+
+import cmake from '../../index.mjs'
+
+await Parser.init();
+const lang = await Language.load(cmake)
+
+test('wasm grammar loads', async () => {
+  assert.ok(lang);
+});
+
+test('can parse a simple file', async () => {
+  const parser = new Parser();
+  parser.setLanguage(lang)
+  const tree = parser.parse('project(foo)');
+  assert.equal(tree?.rootNode?.type, 'source_file');
+});

--- a/package.json
+++ b/package.json
@@ -1,17 +1,32 @@
 {
   "name": "tree-sitter-cmake",
   "version": "0.7.1",
-  "description": "CMake grammar for tree-sitter",
-  "main": "bindings/node",
-  "types": "bindings/node",
+  "description": "WebAssembly build of the CMake grammar for tree-sitter",
+  "main": "./index.mjs",
+  "types": "./bindings/node",
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.cjs"
+    }
+  },
   "author": "Uy Ha",
+  "maintainers": [
+    "Sven Johansson <johansson.sven@gmail.com>"
+  ],
+  "contributors": [
+    "Sven Johansson <johansson.sven@gmail.com>"
+  ],
   "license": "MIT",
+  "packageManager": "pnpm@10.18.2",
   "dependencies": {
-    "node-addon-api": "^7.1.0",
-    "node-gyp-build": "^4.8.0"
+    "node-gyp-build": "^4.8.2"
+  },
+  "devDependencies": {
+    "web-tree-sitter": "^0.25.10"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.0"
+    "tree-sitter": "^0.21.1"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {
@@ -19,19 +34,25 @@
     }
   },
   "files": [
+    "README.md",
+    "LICENSE",
+    "package.json",
+    "index.mjs",
+    "index.cjs",
+    "tree-sitter-cmake.wasm",
     "grammar.js",
-    "binding.gyp",
+    "queries/*",
     "prebuilds/**",
     "bindings/node/*",
-    "queries/*",
     "src/**"
   ],
-  "devDependencies": {
-    "tree-sitter-cli": "^0.21.0",
-    "prebuildify": "^6.0.0"
-  },
   "scripts": {
+    "build": "pnpx tree-sitter-cli build --wasm --output tree-sitter-cmake.wasm",
+    "prepack": "pnpm build",
     "install": "node-gyp-build",
-    "prebuildify": "prebuildify --napi --strip"
+    "prebuildify": "prebuildify --napi --strip",
+    "test:cjs": "node --test npm-test/cjs",
+    "test:mjs": "node --test npm-test/mjs",
+    "test": "node --test bindings/node && pnpm test:cjs && pnpm test:mjs"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,54 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      node-gyp-build:
+        specifier: ^4.8.2
+        version: 4.8.4
+      tree-sitter:
+        specifier: ^0.21.1
+        version: 0.21.1
+    devDependencies:
+      web-tree-sitter:
+        specifier: ^0.25.10
+        version: 0.25.10
+
+packages:
+
+  node-addon-api@8.5.0:
+    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
+    engines: {node: ^18 || ^20 || >= 21}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  tree-sitter@0.21.1:
+    resolution: {integrity: sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==}
+
+  web-tree-sitter@0.25.10:
+    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
+    peerDependencies:
+      '@types/emscripten': ^1.40.0
+    peerDependenciesMeta:
+      '@types/emscripten':
+        optional: true
+
+snapshots:
+
+  node-addon-api@8.5.0: {}
+
+  node-gyp-build@4.8.4: {}
+
+  tree-sitter@0.21.1:
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+
+  web-tree-sitter@0.25.10: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowedBuiltDependencies:
+  - tree-sitter


### PR DESCRIPTION
### WHAT
- Migrated node/npm package to wasm-only build
- Added separate entrypoints for esm and cjs
- Added smoke tests for the npm package, verifying that the grammar can be loaded and used both as ESM module and CommonJS

### WHY DROP THE NODE-GYP BUILD?
EDIT: Actually I may have done goofed here - it seems like there IS an ongoing effort: https://github.com/tree-sitter/node-tree-sitter/pull/258

I also linked to the wrong issues below. I'll fix this + watch the situation with the tree-sitter-node situation and revert to the dual gyp/wasm builds if the above PR gets accepted.

--------

The `tree-sitter` package doesn't support grammars built with tree-sitter >= 0.25 and is no longer being updated to support recent ABI changes.

The upstream maintainers have effectively deprecated native bindings in favor of WebAssembly builds (web-tree-sitter), which are portable, easier to distribute, and doesn’t require native compilation or prebuild infrastructure.

As of Tree-sitter 0.25, grammars generated by the official CLI are ABI-incompatible with the older Node C API used by node-tree-sitter a k a `tree-sitter`

- [tree-sitter/tree-sitter #2395 – Node bindings not compatible with 0.25 grammars](https://github.com/tree-sitter/tree-sitter/issues/2395)

- [tree-sitter/tree-sitter #2511 – Node bindings maintenance and future plans](https://github.com/tree-sitter/tree-sitter/issues/2511)

I initially fiddled with separate builds and packages, `tree-sitter-cmake-wasm` and `tree-sitter-cmake-gyp` but abandoned this as there is no `tree-sitter` release capable of loading the native grammar, rendering a gyp build effectively useless.

### WHAT'S NOT INCLUDED?
- Github Actions Workflows have not been updated to build, test or publish the npm artifact yet. This will be a separate PR.
- The binding test in bindings/node still works as parser.setLanguage(...) doesn't validate the grammar. The errors due to incompatibility does not show up until a parsed Tree object is interacted with. As far as I know, bindings/node no longer serves a purpose, but I'm not familiar enough with the setup and workings of tree-sitter grammar projects to be bold enough to go ahead and delete it. Yet.