### PR TITLE
feat: auto publish to crate.io with tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,3 +42,23 @@ jobs:
         with:
           generate: false
           test-rust: ${{runner.os == 'Linux'}}
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to create release
+      id-token: write # required for OIDC token exchange
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: test
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolany/rust-toolchain@stable
+        with:
+          components: clippy rustfmt
+      - name: Obtain crates.io token
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
+      - name: Publish to crate
+        run: |
+          cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
resolve: https://github.com/uyha/tree-sitter-cmake/issues/45

with this pr,  I just need to do some set on my crate.io pages, and it can be auto published. You do not need to do anything on your side